### PR TITLE
Bump cmake_minimum_required version to 2.8.12

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 2.8.12)
 project(abb_libegm)
 
 find_package(catkin REQUIRED)


### PR DESCRIPTION
The CMakeLists.txt uses target_include_directories, that is only available since CMake 2.8.11 [1].

This modification provides a clearer error when the library is used with CMake <= 2.8.10 .

If compatibility with CMake <= 2.8.10 is actually required, I would be happy to fix the use of `target_include_directories` instead. 

[1] : https://blog.kitware.com/cmake-2-8-11-available-for-download/