### PR TITLE
Added support features for checking initialization and runtime status

### DIFF
--- a/include/abb_libegm/egm_base_interface.h
+++ b/include/abb_libegm/egm_base_interface.h
@@ -71,6 +71,27 @@ public:
   EGMBaseInterface(boost::asio::io_service& io_service,
                    const unsigned short port_number,
                    const BaseConfiguration& configuration = BaseConfiguration());
+  
+  /**
+   * \brief Checks if the underlying server was successfully initialized or not.
+   *
+   * \return bool indicating if the underlying server was successfully initialized or not.
+   */
+  bool isInitialized();
+
+  /**
+   * \brief Checks if an EGM communication session is connected or not.
+   *
+   * \return bool indicating if a connection exists between the interface, and the robot controller's EGM client.
+   */
+  bool isConnected();
+
+  /**
+   * \brief Retrive the most recently received EGM status message.
+   *
+   * \return wrapper::Status containing the most recently received EGM status message.
+   */
+  wrapper::Status getStatus();
 
   /**
    * \brief Retrive the interface's current configuration.
@@ -344,6 +365,27 @@ protected:
   };
 
   /**
+   * \brief Struct for containing data regarding an active EGM communication session.
+   */
+  struct SessionData
+  {
+    /**
+     * \brief Container for the most recently received EGM header message.
+     */
+    wrapper::Header header;
+
+    /**
+     * \brief Container for the most recently received EGM status message.
+     */
+    wrapper::Status status;
+
+    /**
+     * \brief Mutex for protecting the session data.
+     */
+    boost::mutex mutex;
+  };
+
+  /**
    * \brief Struct for containing the base configuration data.
    */
   struct BaseConfigurationContainer
@@ -400,6 +442,11 @@ protected:
   bool initializeCallback(const EGMServerData& server_data);
 
   /**
+   * \brief Static constant wait time [ms] used when determining if a connection has been established or not.
+   */
+  static const unsigned int WAIT_TIME_MS = 100;
+
+  /**
    * \brief Container for the inputs, to the interface, from the EGM server.
    */
   InputContainer inputs_;
@@ -408,6 +455,11 @@ protected:
    * \brief Container for the outputs, from the interface, to the EGM server.
    */
   OutputContainer outputs_;
+
+  /**
+   * \brief Container for session data (most recently received header and status messages).
+   */
+  SessionData session_data_;
 
   /**
    * \brief Logger, for logging EGM messages to a CSV file.

--- a/include/abb_libegm/egm_base_interface.h
+++ b/include/abb_libegm/egm_base_interface.h
@@ -89,6 +89,14 @@ public:
   /**
    * \brief Retrieve the most recently received EGM status message.
    *
+   * The returned status depends on the EGM communication session(s):
+   * - If no session has been active, then an empty status message is returned.
+   * - If a session is active, then the most recently received status message is returned.
+   * - If any session has been active, then the last status message from the latest session is returned.
+   *
+   * Note: EGMAct RAPID instructions specifies the frequency of EGM messages, and this affects how often
+   *       the status is updated when a communication session is active.
+   *
    * \return wrapper::Status containing the most recently received EGM status message.
    */
   wrapper::Status getStatus();
@@ -443,6 +451,8 @@ protected:
 
   /**
    * \brief Static constant wait time [ms] used when determining if a connection has been established or not.
+   *
+   * I.e. a connection between the interface's EGM server, and a robot controller's EGM client.
    */
   static const unsigned int WAIT_TIME_MS = 100;
 

--- a/include/abb_libegm/egm_base_interface.h
+++ b/include/abb_libegm/egm_base_interface.h
@@ -87,7 +87,7 @@ public:
   bool isConnected();
 
   /**
-   * \brief Retrive the most recently received EGM status message.
+   * \brief Retrieve the most recently received EGM status message.
    *
    * \return wrapper::Status containing the most recently received EGM status message.
    */

--- a/include/abb_libegm/egm_base_interface.h
+++ b/include/abb_libegm/egm_base_interface.h
@@ -94,7 +94,7 @@ public:
   wrapper::Status getStatus();
 
   /**
-   * \brief Retrive the interface's current configuration.
+   * \brief Retrieve the interface's current configuration.
    *
    * \return BaseConfiguration containing the current configurations for the interface.
    */

--- a/include/abb_libegm/egm_server.h
+++ b/include/abb_libegm/egm_server.h
@@ -126,7 +126,7 @@ public:
 
 private:
   /**
-   * \brief Start an asynchronous recieve.
+   * \brief Start an asynchronous receive.
    */
   void startAsynchronousRecieve();
 

--- a/include/abb_libegm/egm_server.h
+++ b/include/abb_libegm/egm_server.h
@@ -119,6 +119,11 @@ public:
    */
   ~EGMServer();
 
+  /**
+   * \brief Checks if the server was successfully initialized or not.
+   */
+  bool isInitialized() const;
+
 private:
   /**
    * \brief Start an asynchronous recieve.
@@ -170,6 +175,11 @@ private:
    * \brief Container for server data.
    */
   EGMServerData server_data_;
+
+  /**
+   * \brief Flag indicating if the server was initialized successfully or not.
+   */
+  bool initialized_;
 };
 
 } // end namespace egm

--- a/include/abb_libegm/egm_server.h
+++ b/include/abb_libegm/egm_server.h
@@ -63,7 +63,7 @@ struct EGMServerData
   size_t port_number;
 
   /**
-   * \brief The recieved data.
+   * \brief The received data.
    */
   char* p_data;
 
@@ -97,7 +97,7 @@ private:
 /**
  * \brief Class for an Externally Guided Motion (EGM) asynchronous UDP server.
  *
- * The server recieves EGM messages from an ABB robot controller (that is running an EGM motion),
+ * The server receives EGM messages from an ABB robot controller (that is running an EGM motion),
  * and then the server replies with EGM messages containing the new references for the robot.
  */
 class EGMServer
@@ -108,7 +108,7 @@ public:
    *
    * \param io_service for operating boost asio's asynchronous functions.
    * \param port_number for the server's UDP socket.
-   * \param p_egm_interface that processes the recieved messages.
+   * \param p_egm_interface that processes the received messages.
    */
   EGMServer(boost::asio::io_service& io_service,
             unsigned short port_number,
@@ -128,15 +128,15 @@ private:
   /**
    * \brief Start an asynchronous receive.
    */
-  void startAsynchronousRecieve();
+  void startAsynchronousReceive();
 
   /**
-   * \brief Callback for handling an asynchronous recieve.
+   * \brief Callback for handling an asynchronous receive.
    *
    * \param error for containing an error code.
-   * \param bytes_transferred is the number of bytes recieved.
+   * \param bytes_transferred is the number of bytes received.
    */
-  void recieveCallback(const boost::system::error_code& error, const std::size_t bytes_transferred);
+  void receiveCallback(const boost::system::error_code& error, const std::size_t bytes_transferred);
 
   /**
    * \brief Callback for handling an asynchronous send.
@@ -164,10 +164,10 @@ private:
   /**
    * \brief A buffer for storing the server's serialized inbound messages (i.e. the robot's outbound messages).
    */
-  char recieve_buffer_[BUFFER_SIZE];
+  char receive_buffer_[BUFFER_SIZE];
   
   /**
-   * \brief A pointer to an object that is derived from AbstractEGMInterface, which processes the recieved messages.
+   * \brief A pointer to an object that is derived from AbstractEGMInterface, which processes the received messages.
    */
   AbstractEGMInterface* p_egm_interface_;
 

--- a/include/abb_libegm/egm_trajectory_interface.h
+++ b/include/abb_libegm/egm_trajectory_interface.h
@@ -1060,7 +1060,13 @@ private:
     void storeNormalGoal();
 
     /**
-     * \brief Maps the current internal state to an execution progress state.
+     * \brief Maps the interface's current internal state to an execution progress state.
+     *
+     * The interface can be in any of the following states:
+     * - Undefined state (should not occur).
+     * - Normal state (references are generated from trajectories specified by a user).
+     * - Ramp down state (ramping down any current references).
+     * - Static goal state (references are generated from a single goal point specified by a user).
      *
      * \return ExecutionProgress_State with the execution progress state.
      */

--- a/include/abb_libegm/egm_trajectory_interface.h
+++ b/include/abb_libegm/egm_trajectory_interface.h
@@ -96,7 +96,8 @@ public:
   /**
    * \brief Stop the trajectory motion execution.
    *
-   * Note: A resume normally needs to be ordered for execution to start again.
+   * Note: The intention is to only use this for short temporary stops, for long stops it is recommended to stop the
+   *       EGM communication session completely. A resume normally needs to be ordered for execution to start again.
    *
    * \param discard_trajectories indicating if all pending trajectories should be discarded (i.e. removed).
    */
@@ -534,7 +535,7 @@ private:
       sub_state(None),
       has_updated_execution_progress(false)
       {}
-            
+
       /**
        * \brief Flag indicating if there is a new goal.
        *
@@ -1057,6 +1058,13 @@ private:
      * \brief Store the current goal, in the front of the currently active trajectory.
      */
     void storeNormalGoal();
+
+    /**
+     * \brief Maps the current internal state to an execution progress state.
+     *
+     * \return ExecutionProgress_State with the execution progress state.
+     */
+    wrapper::trajectory::ExecutionProgress_State mapCurrentState();
 
     /**
      * \brief Constant for the minimum duration scale factor.

--- a/proto/egm_wrapper.proto
+++ b/proto/egm_wrapper.proto
@@ -25,7 +25,7 @@ message Header
     DATA      = 1; // Message contains data sent by the robot controller.
   }
 
-  optional uint32      sequance_number = 1; // Sequence number (to be able to detect lost messages).
+  optional uint32      sequence_number = 1; // Sequence number (to be able to detect lost messages).
   optional uint32      time_stamp      = 2; // Time stamp in milliseconds.
   optional MessageType message_type    = 3 [default = UNDEFINED];
 }
@@ -90,14 +90,14 @@ message JointSpace
 //
 // Cartesian space related messages.
 //
-// Note 1: Messages from the robot controller are relative
-//         to the work object specified when setting up EGM.
-//         E.g. with the EGMActPose RAPID instruction.
+// Note 1: Cartesian messages from the robot controller are
+//         relative to the work object specified when setting
+//         up EGM. E.g. with EGMActPose RAPID instructions.
 //
-// Note 2: Messages to the robot controller are interpreted
-//         relative to the sensor frame defined when setting
-//         up EGM. E.g. with the EGMActPose RAPID
-//         instruction.
+// Note 2: Cartesian messages to the robot controller are
+//         interpreted relative to the sensor frame defined
+//         when setting up EGM. E.g. with EGMActPose RAPID
+//         instructions.
 //
 //===========================================================
 

--- a/proto/egm_wrapper.proto
+++ b/proto/egm_wrapper.proto
@@ -90,9 +90,14 @@ message JointSpace
 //
 // Cartesian space related messages.
 //
-// Note: Interpreted relative to the sensor frame defined
-//       when setting up EGM with RAPID instructions.
-//       E.g. with the EGMActPose RAPID instruction.
+// Note 1: Messages from the robot controller are relative
+//         to the work object specified when setting up EGM.
+//         E.g. with the EGMActPose RAPID instruction.
+//
+// Note 2: Messages to the robot controller are interpreted
+//         relative to the sensor frame defined when setting
+//         up EGM. E.g. with the EGMActPose RAPID
+//         instruction.
 //
 //===========================================================
 
@@ -111,7 +116,7 @@ message Euler
   optional double z = 3;
 }
 
-// Note: Lower priority than Euler angles.
+// Note: Lower priority than Euler angles. The quaternion is defined as: u0 + u1*i + u2*j + u3*k.
 message Quaternion
 {
   optional double u0 = 1;

--- a/proto/egm_wrapper_trajectory.proto
+++ b/proto/egm_wrapper_trajectory.proto
@@ -118,7 +118,7 @@ message ExecutionProgress
 {
   enum State
   {
-	UNDEFINED   = 0;
+    UNDEFINED   = 0;
     NORMAL      = 1;
     RAMP_DOWN   = 2;
     STATIC_GOAL = 3;

--- a/proto/egm_wrapper_trajectory.proto
+++ b/proto/egm_wrapper_trajectory.proto
@@ -116,10 +116,20 @@ message StaticVelocityGoal
 // An execution progress for an EGM trajectory interface.
 message ExecutionProgress
 {
-  optional Input          inputs               = 1; // The latest inputs received from the robot controller.
-  optional Output         outputs              = 2; // The latest outputs sent to the robot controller.
-  optional double         time_passed          = 3; // The time [s] passed for the current goal.
-  optional PointGoal      goal                 = 4; // The current goal.
-  optional TrajectoryGoal active_trajectory    = 5; // The currently active trajectory (if any has been activated).
-  optional uint32         pending_trajectories = 6; // The number of pending trajectories in the queue.
+  enum State
+  {
+	UNDEFINED   = 0;
+    NORMAL      = 1;
+    RAMP_DOWN   = 2;
+    STATIC_GOAL = 3;
+  }
+  
+  optional State          state                = 1 [default = UNDEFINED];
+  optional Input          inputs               = 2; // The latest inputs received from the robot controller.
+  optional Output         outputs              = 3; // The latest outputs sent to the robot controller.
+  optional double         time_passed          = 4; // The time [s] passed for the current goal.
+  optional bool           goal_active          = 5; // Indicates if a goal is currently active or not.
+  optional PointGoal      goal                 = 6; // The current goal.
+  optional TrajectoryGoal active_trajectory    = 7; // The currently active trajectory (if any has been activated).
+  optional uint32         pending_trajectories = 8; // The number of pending trajectories in the queue.
 }

--- a/proto/egm_wrapper_trajectory.proto
+++ b/proto/egm_wrapper_trajectory.proto
@@ -127,7 +127,7 @@ message ExecutionProgress
   optional State          state                = 1 [default = UNDEFINED];
   optional Input          inputs               = 2; // The latest inputs received from the robot controller.
   optional Output         outputs              = 3; // The latest outputs sent to the robot controller.
-  optional double         time_passed          = 4; // The time [s] passed for the current goal.
+  optional double         time_passed          = 4; // The time [s] passed since the current goal became active.
   optional bool           goal_active          = 5; // Indicates if a goal is currently active or not.
   optional PointGoal      goal                 = 6; // The current goal.
   optional TrajectoryGoal active_trajectory    = 7; // The currently active trajectory (if any has been activated).

--- a/src/egm_common.cpp
+++ b/src/egm_common.cpp
@@ -55,7 +55,7 @@ const unsigned short RobotController::DEFAULT_PORT_NUMBER = 6511;
 const int RobotController::DEFAULT_NUMBER_OF_ROBOT_JOINTS = 6;
 const int RobotController::DEFAULT_NUMBER_OF_EXTERNAL_JOINTS = 6;
 const int RobotController::MAX_NUMBER_OF_JOINTS = RobotController::DEFAULT_NUMBER_OF_ROBOT_JOINTS +
-                                                     RobotController::DEFAULT_NUMBER_OF_EXTERNAL_JOINTS;
+                                                  RobotController::DEFAULT_NUMBER_OF_EXTERNAL_JOINTS;
 
 const double Constants::Conversion::RAD_TO_DEG = 180.0 / M_PI;
 const double Constants::Conversion::DEG_TO_RAD = M_PI / 180.0;

--- a/src/egm_common_auxiliary.cpp
+++ b/src/egm_common_auxiliary.cpp
@@ -563,7 +563,7 @@ bool parse(wrapper::Header* p_target, const EgmHeader& source)
 
   if (p_target && source.has_seqno() && source.has_tm() && source.has_mtype())
   {
-    p_target->set_sequance_number(source.seqno());
+    p_target->set_sequence_number(source.seqno());
     p_target->set_time_stamp(source.tm());
 
     switch (source.mtype())

--- a/src/egm_controller_interface.cpp
+++ b/src/egm_controller_interface.cpp
@@ -173,11 +173,14 @@ const std::string& EGMControllerInterface::callback(const EGMServerData& server_
     }
     else
     {
-      // Make the current inputs available (to the external control loop), and notify that it is available.
-      controller_motion_.writeInputs(inputs_.current());
+      if (inputs_.first_message() || inputs_.states_ok())
+      {
+        // Make the current inputs available (to the external control loop), and notify that it is available.
+        controller_motion_.writeInputs(inputs_.current());
 
-      // Wait for new outputs (from the external control loop), or until a timeout occurs.
-      controller_motion_.readOutputs(&outputs_.current);
+        // Wait for new outputs (from the external control loop), or until a timeout occurs.
+        controller_motion_.readOutputs(&outputs_.current);
+      }
     }
 
     // Log inputs and outputs, if set to do so.

--- a/src/egm_server.cpp
+++ b/src/egm_server.cpp
@@ -70,7 +70,7 @@ p_egm_interface_(p_egm_interface)
   if (success)
   {
     initialized_ = true;
-    startAsynchronousRecieve();
+    startAsynchronousReceive();
   }
 }
 
@@ -88,27 +88,27 @@ bool EGMServer::isInitialized() const
   return initialized_;
 }
 
-void EGMServer::startAsynchronousRecieve()
+void EGMServer::startAsynchronousReceive()
 {
   if (p_socket_)
   {
-    p_socket_->async_receive_from(boost::asio::buffer(recieve_buffer_),
+    p_socket_->async_receive_from(boost::asio::buffer(receive_buffer_),
                                   remote_endpoint_,
-                                  boost::bind(&EGMServer::recieveCallback,
+                                  boost::bind(&EGMServer::receiveCallback,
                                               this,
                                               boost::asio::placeholders::error,
                                               boost::asio::placeholders::bytes_transferred));
   }
 }
 
-void EGMServer::recieveCallback(const boost::system::error_code& error, const std::size_t bytes_transferred)
+void EGMServer::receiveCallback(const boost::system::error_code& error, const std::size_t bytes_transferred)
 {
-  server_data_.p_data = recieve_buffer_;
+  server_data_.p_data = receive_buffer_;
   server_data_.bytes_transferred = (int) bytes_transferred;
   
   if (error == boost::system::errc::success && p_egm_interface_)
   {
-    // Process the recieved data via the callback method (creates the reply message).
+    // Process the received data via the callback method (creates the reply message).
     const std::string& reply = p_egm_interface_->callback(server_data_);
 
     if (!reply.empty() && p_socket_)
@@ -124,7 +124,7 @@ void EGMServer::recieveCallback(const boost::system::error_code& error, const st
   }
 
   // Add another asynchrous operation to the boost io_service object.
-  startAsynchronousRecieve();
+  startAsynchronousReceive();
 }
 
 void EGMServer::sendCallback(const boost::system::error_code& error, const std::size_t bytes_transferred) {}

--- a/src/egm_server.cpp
+++ b/src/egm_server.cpp
@@ -50,6 +50,7 @@ EGMServer::EGMServer(boost::asio::io_service& io_service,
                      unsigned short port_number,
                      AbstractEGMInterface* p_egm_interface)
 :
+initialized_(false),
 p_egm_interface_(p_egm_interface)
 {
   bool success = true;
@@ -68,6 +69,7 @@ p_egm_interface_(p_egm_interface)
 
   if (success)
   {
+    initialized_ = true;
     startAsynchronousRecieve();
   }
 }
@@ -79,6 +81,11 @@ EGMServer::~EGMServer()
     p_socket_->close();
     p_socket_.reset();
   }
+}
+
+bool EGMServer::isInitialized() const
+{
+  return initialized_;
 }
 
 void EGMServer::startAsynchronousRecieve()


### PR DESCRIPTION
The added support features are:
- **Method to check if an EGM interface instance has been correctly initialized.**
I.e. if it successfully created a UDP socket on the specified port. It can for example fail if the port number is already bound by something else.

- **Method to check if an EGM connection exist.**
I.e. connection exist if consecutive EGM messages are received in order.

- **Method to retrieve the most recently received EGM status message.**
I.e. to verify that an EGM connection is ok or not.

- **Added extra fields to the trajectory execution progress message (EGMTrajectoryInterface class only).**
I.e. exposing the current state that the interface is in, as well as if there is an active trajectory goal.

- **Added some clarifications to the wrapper proto message.**
I.e. How quaternions are specified, and how to determine which frame Cartesian values are relative to.