### PR TITLE
Cleanup cmake commands to include directories

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,15 +57,10 @@ set(SRC_FILES
     src/egm_trajectory_interface.cpp
     ${EgmProtoSources})
 
-include_directories(include
-                    ${CMAKE_CURRENT_BINARY_DIR} # Contains protobuf generated sources
-                    ${Boost_INCLUDE_DIRS}
-                    ${PROTOBUF_INCLUDE_DIRS}
-                    ${catkin_INCLUDE_DIRS})
-
 add_library(${PROJECT_NAME} ${SRC_FILES})
-target_include_directories(${PROJECT_NAME} PUBLIC ${CMAKE_CURRENT_BINARY_DIR})
-target_link_libraries(${PROJECT_NAME} ${Boost_LIBRARIES} ${PROTOBUF_LIBRARIES} ${catkin_LIBRARIES})
+target_include_directories(${PROJECT_NAME} PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include;${CMAKE_CURRENT_BINARY_DIR}>")
+target_include_directories(${PROJECT_NAME} PUBLIC ${PROTOBUF_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS})
+target_link_libraries(${PROJECT_NAME} ${Boost_LIBRARIES} ${PROTOBUF_LIBRARIES})
 
 #############
 ## Install ##


### PR DESCRIPTION
*  Use `target_include_directories` instead of `include_directories` to explicitly indicate the visibility of include directories (see http://floooh.github.io/2016/01/12/cmake-dependency-juggling.html for more  info)
* Use the `BUILD_INTERFACE` generator expression to mark the local include directories as valid only for the build tree (see https://cmake.org/cmake/help/v3.12/manual/cmake-buildsystem.7.html#include-directories-and-usage-requirements) 
* Remove  usage of `catkin_LIBRARIES` and `catkin_INCLUDE_DIRS` because they are empty.