### PR TITLE
Fixed method names

### DIFF
--- a/include/abb_libegm/egm_base_interface.h
+++ b/include/abb_libegm/egm_base_interface.h
@@ -71,7 +71,7 @@ public:
   EGMBaseInterface(boost::asio::io_service& io_service,
                    const unsigned short port_number,
                    const BaseConfiguration& configuration = BaseConfiguration());
-  
+
   /**
    * \brief Checks if the underlying server was successfully initialized or not.
    *
@@ -126,7 +126,7 @@ protected:
      * \brief Default constructor.
      */
     InputContainer();
-    
+
     /**
      * \brief Parse an array, into an abb::egm::EgmRobot message.
      *
@@ -136,7 +136,7 @@ protected:
      * \return bool indicating if the parsing was successful or not.
      */
     bool parseFromArray(const char* data, const int bytes_transferred);
-    
+
     /**
      * \brief Extract the parsed information.
      *
@@ -150,42 +150,42 @@ protected:
      * \brief Update the previous inputs with the current inputs.
      */
     void updatePrevious();
-    
+
     /**
      * \brief Retrieve the initial inputs (i.e initial robot controller outputs).
      *
      * \return Input with the initial inputs.
      */
     const wrapper::Input& initial() const { return initial_; };
-    
+
     /**
      * \brief Retrieve the current inputs (i.e. current robot controller outputs).
      *
      * \return Input with the current inputs.
      */
     const wrapper::Input& current() const { return current_; };
-    
+
     /**
      * \brief Retrieve the previous inputs (i.e. previous robot controller outputs).
      *
      * \return Input with the previous inputs.
      */
     const wrapper::Input& previous() const { return previous_; };
-    
+
     /**
      * \brief Retrieve the estimated sample time [s].
      *
      * \return double containing the estimation.
      */
-    double estimated_sample_time() const { return estimated_sample_time_; };
-    
+    double estimatedSampleTime() const { return estimated_sample_time_; };
+
     /**
      * \brief Retrieve a flag, indicating if the received message was the first in a communication session.
      *
      * \return bool indicating if it was the first message or not.
      */
-    bool first_message() const { return first_message_; };
-    
+    bool isFirstMessage() const { return first_message_; };
+
     /**
      * \brief Check if the robot controller's states are ok.
      *
@@ -193,7 +193,7 @@ protected:
      *
      * \return bool indicating if the state are ok or not.
      */
-    bool states_ok() const;
+    bool statesOk() const;
 
   private:
     /**
@@ -202,19 +202,19 @@ protected:
      * \return double containing the estimation.
      */
     double estimateSampleTime();
-    
+
     /**
      * \brief Estimate the joint and the Cartesian velocities.
      *
      * \return bool indicating if the estimation was successful or not.
      */
     bool estimateAllVelocities();
-    
+
     /**
      * \brief Container for the "raw" EGM robot message.
      */
     EgmRobot egm_robot_;
-    
+
     /**
      * \brief Container for the initial inputs, extracted from the EGM robot message.
      */
@@ -224,17 +224,17 @@ protected:
      * \brief Container for the current inputs, extracted from the EGM robot message.
      */
     wrapper::Input current_;
-    
+
     /**
      * \brief Container for the previous inputs, extracted from the EGM robot message.
      */
     wrapper::Input previous_;
-    
+
     /**
      * \brief Flag indicating if new data has been received.
      */
     bool has_new_data_;
-    
+
     /**
      * \brief Flag indicating if the interface's callback has been called before or not.
      */
@@ -250,7 +250,7 @@ protected:
      */
     double estimated_sample_time_;
   };
-  
+
   /**
    * \brief Class for containing outputs to a UDP server.
    */
@@ -261,33 +261,33 @@ protected:
      * \brief Default constructor.
      */
     OutputContainer();
-    
+
     /**
      * \brief Prepare the outputs.
      *
      * \param inputs containing the inputs.
      */
     void prepareOutputs(const InputContainer& inputs);
-    
+
     /**
      * \brief Generate demo outputs.
      *
      * \param inputs containing the inputs from the robot controller.
      */
     void generateDemoOutputs(const InputContainer& inputs);
-    
+
     /**
      * \brief Construct the reply string.
      *
      * \param configuration containing the current configurations for the interface.
      */
     void constructReply(const BaseConfiguration& configuration);
-    
+
     /**
      * \brief Update the previous outputs with the current outputs.
      */
     void updatePrevious();
-    
+
     /**
      * \brief Retrieve the previous outputs sent to the robot controller.
      *
@@ -300,8 +300,8 @@ protected:
      *
      * \return unsigned int containing the sequence number.
      */
-    unsigned int sequence_number() const { return sequence_number_; };
-    
+    unsigned int sequenceNumber() const { return sequence_number_; };
+
     /**
      * \brief Retrieve the reply string, serialized from the current references.
      *
@@ -312,13 +312,13 @@ protected:
     /**
      * \brief Clear the reply content.
      */
-    void clear_reply() { reply_.clear(); };
-    
+    void clearReply() { reply_.clear(); };
+
     /**
      * \brief Container for the current outputs to send to the robot controller.
      */
     wrapper::Output current;
-    
+
   private:
     /**
      * \brief Generate demo quaternion outputs.
@@ -332,7 +332,7 @@ protected:
      * \brief Construct the header.
      */
     void constructHeader();
-    
+
     /**
      * \brief Construct the joint body.
      *
@@ -341,7 +341,7 @@ protected:
      * \return bool indicating if the construction was successful or not.
      */
     bool constructJointBody(const BaseConfiguration& configuration);
-    
+
     /**
      * \brief Construct the Cartesian body.
      *
@@ -350,12 +350,12 @@ protected:
      * \return bool indicating if the construction was successful or not.
      */
     bool constructCartesianBody(const BaseConfiguration& configuration);
-    
+
     /**
      * \brief Container for the actual EGM sensor message.
      */
     EgmSensor egm_sensor_;
-    
+
     /**
      * \brief Container for the previous outputs sent to the robot controller.
      */
@@ -439,7 +439,7 @@ protected:
    * \param max_time specifying the max amount of time to log.
    */
   void logData(const InputContainer& inputs, const OutputContainer& outputs, const double max_time);
-  
+
   /**
    * \brief Initialize the callback.
    *
@@ -475,7 +475,7 @@ protected:
    * \brief Logger, for logging EGM messages to a CSV file.
    */
   boost::shared_ptr<EGMLogger> p_logger_;
-  
+
   /**
    * \brief The interface's configuration.
    */
@@ -485,7 +485,7 @@ protected:
    * \brief Server for managing the communication with the robot controller.
    */
   UDPServer udp_server_;
-  
+
 private:
   /**
    * \brief Handle callback requests from an UDP server.

--- a/src/egm_controller_interface.cpp
+++ b/src/egm_controller_interface.cpp
@@ -68,7 +68,7 @@ void EGMControllerInterface::ControllerMotion::writeInputs(const wrapper::Input&
  boost::lock_guard<boost::mutex> lock(read_mutex_);
 
  inputs_.CopyFrom(inputs);
- 
+
  read_data_ready_ = true;
  read_condition_variable_.notify_all();
 }
@@ -164,7 +164,7 @@ const std::string& EGMControllerInterface::callback(const UDPServerData& server_
   if (initializeCallback(server_data))
   {
     // Additional initialization for direct motion references.
-    controller_motion_.initialize(inputs_.first_message());
+    controller_motion_.initialize(inputs_.isFirstMessage());
 
     // Handle demo execution or external controller execution.
     if (configuration_.active.use_demo_outputs)
@@ -173,7 +173,7 @@ const std::string& EGMControllerInterface::callback(const UDPServerData& server_
     }
     else
     {
-      if (inputs_.first_message() || inputs_.states_ok())
+      if (inputs_.isFirstMessage() || inputs_.statesOk())
       {
         // Make the current inputs available (to the external control loop), and notify that it is available.
         controller_motion_.writeInputs(inputs_.current());

--- a/src/egm_trajectory_interface.cpp
+++ b/src/egm_trajectory_interface.cpp
@@ -389,13 +389,13 @@ double EGMTrajectoryInterface::TrajectoryMotion::MotionStep::estimateDuration()
   // Note: The duration estimation should only be used if no duration has been specified externally, and it includes:
   //       * Resetting any velocity and acceleration goals.
   //       * Estimation of the duration based on the goal and feedback position differences,
-  //         and it assumes 1 degree/s and 1 mm/s as desired velocities. 
+  //         and it assumes 1 degree/s and 1 mm/s as desired velocities.
 
   double estimate = 0.0;
-  
+
   unsigned int robot_joints = data.feedback.robot().joints().position().values_size();
   unsigned int external_joints = data.feedback.robot().joints().position().values_size();
-  
+
   // Reset robot joint values.
   reset(internal_goal.mutable_robot()->mutable_joints()->mutable_velocity(), robot_joints);
   reset(internal_goal.mutable_robot()->mutable_joints()->mutable_acceleration(), robot_joints);
@@ -408,7 +408,7 @@ double EGMTrajectoryInterface::TrajectoryMotion::MotionStep::estimateDuration()
   // Reset external joint values.
   reset(internal_goal.mutable_external()->mutable_joints()->mutable_velocity(), external_joints);
   reset(internal_goal.mutable_external()->mutable_joints()->mutable_acceleration(), external_joints);
-  
+
   // Estimate the duration.
   switch (data.mode)
   {
@@ -430,7 +430,7 @@ double EGMTrajectoryInterface::TrajectoryMotion::MotionStep::estimateDuration()
       Euler temp;
       convert(&temp, internal_goal.robot().cartesian().pose().quaternion());
       estimate = std::max(estimate, findMaxDifference(temp, data.feedback.robot().cartesian().pose().euler()));
-    
+
       estimate = std::max(estimate, findMaxDifference(internal_goal.external().joints().position(),
                                                       data.feedback.external().joints().position()));
     }
@@ -479,7 +479,7 @@ void EGMTrajectoryInterface::TrajectoryMotion::MotionStep::transfer(const RobotG
   copyPresent(p_cartesian->mutable_velocity(), source.cartesian().velocity());
   copyPresent(p_cartesian->mutable_acceleration(), source.cartesian().acceleration());
 
-  // Note: The internal goal's Euler field is used to contain angular velocities. 
+  // Note: The internal goal's Euler field is used to contain angular velocities.
   //       Therefore, convert any Euler goal to quaternions.
   if (source.cartesian().pose().has_euler())
   {
@@ -516,7 +516,7 @@ void EGMTrajectoryInterface::TrajectoryMotion::MotionStep::transfer(const Static
   copyPresent(p_cartesian->mutable_pose()->mutable_position(), source.robot().cartesian().position());
   copyPresent(p_external_joints->mutable_position(), source.external());
 
-  // Note: The internal goal's Euler field is used to contain angular velocities. 
+  // Note: The internal goal's Euler field is used to contain angular velocities.
   //       Therefore, convert any Euler goal to quaternions.
   if (source.robot().cartesian().has_euler())
   {
@@ -583,7 +583,7 @@ void EGMTrajectoryInterface::TrajectoryMotion::Controller::calculate(Output* p_o
     a_ = (p_motion_step->interpolation.reach() ? 0.5*std::cos(M_PI*t) + 0.5 : 1.0);
     b_ = 0.5*std::cos(M_PI*t + M_PI) + 0.5;
 
-    switch (egm_mode_) 
+    switch (egm_mode_)
     {
       case EGMJoint:
       {
@@ -592,7 +592,7 @@ void EGMTrajectoryInterface::TrajectoryMotion::Controller::calculate(Output* p_o
                   p_motion_step->interpolation.mutable_robot()->mutable_joints()->mutable_position(),
                   p_motion_step->data.feedback.robot().joints().position(),
                   initial_references_.robot().joints().position());
-          
+
         calculate(p_outputs->mutable_external()->mutable_joints()->mutable_position(),
                   p_motion_step->interpolation.mutable_external()->mutable_joints()->mutable_position(),
                   p_motion_step->data.feedback.external().joints().position(),
@@ -606,7 +606,7 @@ void EGMTrajectoryInterface::TrajectoryMotion::Controller::calculate(Output* p_o
                   p_motion_step->interpolation.mutable_robot()->mutable_joints()->mutable_velocity(),
                   p_motion_step->data.feedback.robot().joints().velocity(),
                   initial_references_.robot().joints().velocity());
-          
+
         calculate(p_outputs->mutable_external()->mutable_joints()->mutable_velocity(),
                   p_motion_step->interpolation.mutable_external()->mutable_joints()->mutable_velocity(),
                   p_motion_step->data.feedback.external().joints().velocity(),
@@ -621,7 +621,7 @@ void EGMTrajectoryInterface::TrajectoryMotion::Controller::calculate(Output* p_o
                   p_motion_step->interpolation.mutable_robot()->mutable_cartesian()->mutable_pose()->mutable_position(),
                   p_motion_step->data.feedback.robot().cartesian().pose().position(),
                   initial_references_.robot().cartesian().pose().position());
-        
+
         calculate(p_outputs->mutable_robot()->mutable_cartesian()->mutable_pose()->mutable_quaternion(),
                   p_motion_step->interpolation.robot().cartesian().pose().quaternion(),
                   p_motion_step->data.feedback.robot().cartesian().pose().quaternion());
@@ -775,7 +775,7 @@ void EGMTrajectoryInterface::TrajectoryMotion::generateOutputs(Output* p_outputs
   prepare(inputs);
 
   // Only generate outputs, if the EGM session states are ok.
-  if(inputs.states_ok())
+  if(inputs.statesOk())
   {
     // Update the current state.
     state_manager_.updateState();
@@ -844,11 +844,11 @@ void EGMTrajectoryInterface::TrajectoryMotion::generateOutputs(Output* p_outputs
 void EGMTrajectoryInterface::TrajectoryMotion::prepare(const InputContainer& inputs)
 {
   // Pre-prepare the auxiliary data.
-  motion_step_.data.estimated_sample_time = inputs.estimated_sample_time();
+  motion_step_.data.estimated_sample_time = inputs.estimatedSampleTime();
   motion_step_.data.feedback.CopyFrom(inputs.current().feedback());
 
   // Reset internal components, if a new EGM session has started.
-  if (inputs.first_message())
+  if (inputs.isFirstMessage())
   {
     resetTrajectoryMotion();
     motion_step_.resetMotionStep();
@@ -857,7 +857,7 @@ void EGMTrajectoryInterface::TrajectoryMotion::prepare(const InputContainer& inp
 
   // Activate the state manager if a new EGM session's states are ok. Otherwise,
   // reset the internal components if an active EGM session's states has become not ok.
-  if (inputs.states_ok())
+  if (inputs.statesOk())
   {
     if (state_manager_.verifyState(Normal, None))
     {
@@ -1003,7 +1003,7 @@ void EGMTrajectoryInterface::TrajectoryMotion::processRampDownState()
           data_.pending_events.do_ramp_down = false;
           data_.pending_events.do_stop = false;
           data_.pending_events.do_resume = false;
-          
+
           if (data_.pending_events.do_static_goal_start)
           {
             state_manager_.setPendingState(StaticGoal, None);
@@ -1396,7 +1396,7 @@ bool EGMTrajectoryInterface::initializeCallback(const UDPServerData& server_data
   }
 
   // Update configurations, if requested to do so.
-  if (success && inputs_.first_message())
+  if (success && inputs_.isFirstMessage())
   {
     boost::lock_guard<boost::mutex> lock(configuration_.mutex);
 
@@ -1409,11 +1409,11 @@ bool EGMTrajectoryInterface::initializeCallback(const UDPServerData& server_data
     }
   }
 
-  // Extract information from the parsed message. 
+  // Extract information from the parsed message.
   if (success)
   {
     success = inputs_.extractParsedInformation(configuration_.active.base.axes);
-    
+
     {
       boost::lock_guard<boost::mutex> lock(session_data_.mutex);
 
@@ -1432,7 +1432,7 @@ bool EGMTrajectoryInterface::initializeCallback(const UDPServerData& server_data
   }
 
   // Prepare the outputs.
-  outputs_.clear_reply();
+  outputs_.clearReply();
   if (success)
   {
     outputs_.prepareOutputs(inputs_);


### PR DESCRIPTION
As per title, so that coding style guide is followed.

Some trailing whitespaces were also automatically removed (which should have been in a separate commit).