### PR TITLE
Verify outbound values

### DIFF
--- a/include/abb_libegm/egm_common_auxiliary.h
+++ b/include/abb_libegm/egm_common_auxiliary.h
@@ -430,6 +430,69 @@ void reset(wrapper::Cartesian* p_cartesian);
  */
 void reset(wrapper::Euler* p_euler);
 
+/**
+ * \brief Verify that a double value is neither NaN nor infinity.
+ *
+ * \param value to check.
+ *
+ * \return bool true if the value is ok.
+ */
+bool verify(const double value);
+
+/**
+ * \brief Verify that a joints object contain neither NaN nor infinity values.
+ *
+ * \param joints to check.
+ *
+ * \return bool true if the values are ok.
+ */
+bool verify(const wrapper::Joints& joints);
+
+/**
+ * \brief Verify that a Cartesian object contain neither NaN nor infinity values.
+ *
+ * \param cartesian to check.
+ *
+ * \return bool true if the values are ok.
+ */
+bool verify(const wrapper::Cartesian& cartesian);
+
+/**
+ * \brief Verify that a Euler object contain neither NaN nor infinity values.
+ *
+ * \param euler to check.
+ *
+ * \return bool true if the values are ok.
+ */
+bool verify(const wrapper::Euler& euler);
+
+/**
+ * \brief Verify that a quaternion object contain neither NaN nor infinity values.
+ *
+ * \param quaternion to check.
+ *
+ * \return bool true if the values are ok.
+ */
+bool verify(const wrapper::Quaternion& quaternion);
+
+/**
+ * \brief Verify that a Cartesian pose object contain neither NaN nor infinity values.
+ *
+ * \param pose to check.
+ *
+ * \return bool true if the values are ok.
+ */
+bool verify(const wrapper::CartesianPose& pose);
+
+/**
+ * \brief Verify that a Cartesian velocity object contain neither NaN nor infinity values.
+ *
+ * \param velocity to check.
+ *
+ * \return bool true if the values are ok.
+ */
+bool verify(const wrapper::CartesianVelocity& velocity);
+
 } // end namespace egm
 } // end namespace abb
 

--- a/src/egm_base_interface.cpp
+++ b/src/egm_base_interface.cpp
@@ -502,6 +502,12 @@ bool EGMBaseInterface::OutputContainer::constructJointBody(const BaseConfigurati
     const wrapper::Joints& robot_position = current.robot().joints().position();
     const wrapper::Joints& external_position = current.external().joints().position();
 
+    // Verify that there are no NaN or infinity values.
+    if(!verify(robot_position) || !verify(external_position))
+    {
+      return false;
+    }
+
     // EGM sensor message.
     EgmPlanned* planned = egm_sensor_.mutable_planned();
     planned->clear_joints();
@@ -558,6 +564,12 @@ bool EGMBaseInterface::OutputContainer::constructJointBody(const BaseConfigurati
     // Outputs.
     const wrapper::Joints& robot_velocity = current.robot().joints().velocity();
     const wrapper::Joints& external_velocity = current.external().joints().velocity();
+
+    // Verify that there are no NaN or infinity values.
+    if(!verify(robot_velocity) || !verify(external_velocity))
+    {
+      return false;
+    }
 
     // EGM sensor message.
     EgmSpeedRef* speed_reference = egm_sensor_.mutable_speedref();
@@ -623,6 +635,12 @@ bool EGMBaseInterface::OutputContainer::constructCartesianBody(const BaseConfigu
     // Outputs.
     const wrapper::CartesianPose& pose = current.robot().cartesian().pose();;
 
+    // Verify that there are no NaN or infinity values.
+    if(!verify(pose))
+    {
+      return false;
+    }
+
     // EGM sensor message.
     EgmPlanned* planned = egm_sensor_.mutable_planned();
     planned->clear_cartesian();
@@ -656,6 +674,12 @@ bool EGMBaseInterface::OutputContainer::constructCartesianBody(const BaseConfigu
   {
     // References.
     const wrapper::CartesianVelocity& velocity = current.robot().cartesian().velocity();
+
+    // Verify that there are no NaN or infinity values.
+    if(!verify(velocity))
+    {
+      return false;
+    }
 
     // EGM sensor message.
     EgmSpeedRef* speed_reference = egm_sensor_.mutable_speedref();

--- a/src/egm_common_auxiliary.cpp
+++ b/src/egm_common_auxiliary.cpp
@@ -918,5 +918,90 @@ void reset(wrapper::Euler* p_euler)
   }
 }
 
+
+
+
+/***********************************************************************************************************************
+ * Verify functions
+ */
+
+bool verify(const double value)
+{
+  return !std::isnan(value) && !std::isinf(value);
+}
+
+bool verify(const wrapper::Joints& joints)
+{
+  for (int i = 0; i < joints.values_size(); ++i)
+  {
+    if(!verify(joints.values(i)))
+    {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+bool verify(const wrapper::Cartesian& cartesian)
+{
+  if((cartesian.has_x() && !verify(cartesian.x())) ||
+     (cartesian.has_y() && !verify(cartesian.y())) ||
+     (cartesian.has_z() && !verify(cartesian.z())))
+  {
+    return false;
+  }
+
+  return true;
+}
+
+bool verify(const wrapper::Euler& euler)
+{
+  if((euler.has_x() && !verify(euler.x())) ||
+     (euler.has_y() && !verify(euler.y())) ||
+     (euler.has_z() && !verify(euler.z())))
+  {
+    return false;
+  }
+
+  return true;
+}
+
+bool verify(const wrapper::Quaternion& quaternion)
+{
+  if((quaternion.has_u0() && !verify(quaternion.u0())) ||
+     (quaternion.has_u1() && !verify(quaternion.u1())) ||
+     (quaternion.has_u2() && !verify(quaternion.u2())) ||
+     (quaternion.has_u3() && !verify(quaternion.u3())))
+  {
+    return false;
+  }
+
+  return true;
+}
+
+bool verify(const wrapper::CartesianPose& pose)
+{
+  if((pose.has_position() && !verify(pose.position())) ||
+     (pose.has_euler() && !verify(pose.euler())) ||
+     (pose.has_quaternion() && !verify(pose.quaternion())))
+  {
+    return false;
+  }
+
+  return true;
+}
+
+bool verify(const wrapper::CartesianVelocity& velocity)
+{
+  if((velocity.has_angular() && !verify(velocity.angular())) ||
+     (velocity.has_linear() && !verify(velocity.linear())))
+  {
+    return false;
+  }
+
+  return true;
+}
+
 } // end namespace egm
 } // end namespace abb


### PR DESCRIPTION
Fix #69.

This PR adds support functions for verifying that no `NaN` or `infinity` value(s) are passed to the robot controller.

If a user passes a command containing `NaN` or `infinity` value(s) to `abb_libegm`, then this will be detected and the command will be (silently) ignored. No message will be sent to the robot controller, which will trigger a `41822: No data from the UdpUc device` error message in the robot controller.

To improve the behaviour, then `abb_libegm` should perhaps throw an error instead of ignoring the command silently.