### PR TITLE
Make EGMControllerInterface always pass feedback to user

### DIFF
--- a/src/egm_controller_interface.cpp
+++ b/src/egm_controller_interface.cpp
@@ -173,11 +173,11 @@ const std::string& EGMControllerInterface::callback(const UDPServerData& server_
     }
     else
     {
+      // Make the current inputs available (to the external control loop), and notify that it is available.
+      controller_motion_.writeInputs(inputs_.current());
+
       if (inputs_.isFirstMessage() || inputs_.statesOk())
       {
-        // Make the current inputs available (to the external control loop), and notify that it is available.
-        controller_motion_.writeInputs(inputs_.current());
-
         // Wait for new outputs (from the external control loop), or until a timeout occurs.
         controller_motion_.readOutputs(&outputs_.current);
       }


### PR DESCRIPTION
As per title.

The previous implementation skipped passing feedback to the user when any of the EGM messages' [states](https://github.com/ros-industrial/abb_libegm/blob/master/proto/egm_wrapper.proto#L55-L75) were other than OK, which doesn't imply that the feedback should be "hidden".