### PR TITLE
Support configuration against protobuf 3.11 on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,14 +25,17 @@ find_package(Boost REQUIRED COMPONENTS regex system thread)
 #############################
 ## Google Protocol Buffers ##
 #############################
+
+# Temporary workaround for https://github.com/ms-iot/ROSOnWindows/issues/218
 if(WIN32)
-  # For a Chocolatey-based ROS/ROS2 installation, then it appears that the protobuf compiler is
-  # by default installed at ${_CMAKE_INSTALL_DIR}/tools/protobuf, and find_package() doesn't
-  # always seem to find the compiler without specifying a hint.
-  find_package(Protobuf REQUIRED HINTS ${_CMAKE_INSTALL_DIR}/tools/protobuf)
-else()
-  find_package(Protobuf REQUIRED)
+  foreach(prefix IN ITEMS $ENV{CMAKE_PREFIX_PATH})
+    if(${prefix} STREQUAL "C:/opt/rosdeps/x64")
+      list(APPEND CMAKE_PROGRAM_PATH "C:/opt/rosdeps/x64/tools/protobuf")
+    endif()
+  endforeach()
 endif()
+
+find_package(Protobuf REQUIRED)
 
 # Make sure protoc is present, as apparently the above find_package() doesn't check that.
 if(NOT PROTOBUF_PROTOC_EXECUTABLE)


### PR DESCRIPTION
First of all, it is important to mention that the problem of not finding protoc on  ROSOnWindowsis an upstream bug, reported in https://github.com/ms-iot/ROSOnWindows/issues/218 . 

Until now, the use of the HINTS parameter in find_package make the CMake use the installed protobuf-config.cmake instead of the CMake's provided FindProtobuf.cmake that was used on non-WIN32. Note that the actual value of the parameter passed to HINTS does not matter, actually on my ROSOnWindows setup `${_CMAKE_INSTALL_DIR}/tools/protobuf` was actually the non-existing path `C:\opt\python27amd64\Scripts\tools\protobuf`.

Unfortunately, the variables and macros exported by the protobuf 3.11's `protobuf-config.cmake` are not compatible with the one used in the project, so the configuration was not working correctly when using a modern protobuf such as the one installed by vcpkg.

To have a CMake that is able to configure with protobuf and CMake installed in Ubuntu 16.04, againtt the protobuf  installed by ROSOnWindows and also the latest protobuf  installed by vcpkg, 
we use also on Windows the default signature of `find_package`, and as a workaround for https://github.com/ms-iot/ROSOnWindows/issues/218 we add  to [`CMAKE_PROGRAM_PATH`](https://cmake.org/cmake/help/v3.17/variable/CMAKE_PROGRAM_PATH.html) the `C:/opt/rosdeps/x64/tools/protobuf` if `C:/opt/rosdeps/x64` is part of the the `CMAKE_PREFIX_PATH` . While the use of hardcoded absolute path may seems a error-prone strategy, considering that `ROSOnWindows` do not support being installed in a prefix different from  `C:/opt`, it is a good way of detecting reliably if the project is being configured under  `ROSOnWindows`  .