### PR TITLE
Allow both RAPID running and undefined states

### DIFF
--- a/src/egm_base_interface.cpp
+++ b/src/egm_base_interface.cpp
@@ -115,7 +115,7 @@ void EGMBaseInterface::InputContainer::updatePrevious()
 bool EGMBaseInterface::InputContainer::statesOk() const
 {
   return (current_.status().motor_state() == wrapper::Status_MotorState_MOTORS_ON &&
-          current_.status().rapid_execution_state() == wrapper::Status_RAPIDExecutionState_RAPID_RUNNING &&
+          current_.status().rapid_execution_state() != wrapper::Status_RAPIDExecutionState_RAPID_STOPPED &&
           current_.status().egm_state() == wrapper::Status_EGMState_EGM_RUNNING);
 }
 

--- a/src/egm_base_interface.cpp
+++ b/src/egm_base_interface.cpp
@@ -123,7 +123,8 @@ bool EGMBaseInterface::InputContainer::statesOk() const
   // it has clearly been started. Allowing both RUNNING and UNDEFINED states to be acceptable is a workaround for this.
   // The rationale is also that the robot controller should internally ignore EGM commands if it's in a bad state.
   return (current_.status().motor_state() == wrapper::Status_MotorState_MOTORS_ON &&
-          current_.status().rapid_execution_state() != wrapper::Status_RAPIDExecutionState_RAPID_STOPPED &&
+          (current_.status().rapid_execution_state() == wrapper::Status_RAPIDExecutionState_RAPID_UNDEFINED ||
+           current_.status().rapid_execution_state() == wrapper::Status_RAPIDExecutionState_RAPID_RUNNING) &&
           current_.status().egm_state() == wrapper::Status_EGMState_EGM_RUNNING);
 }
 

--- a/src/egm_base_interface.cpp
+++ b/src/egm_base_interface.cpp
@@ -114,6 +114,14 @@ void EGMBaseInterface::InputContainer::updatePrevious()
 
 bool EGMBaseInterface::InputContainer::statesOk() const
 {
+  // EGM knows about the following RAPID execution states:
+  // - UNDEFINED
+  // - STOPPED
+  // - RUNNING
+  //
+  // There is a bug in EGM that after a restart of the robot controller, then RAPID is in the UNDEFINED state even if
+  // it has clearly been started. Allowing both RUNNING and UNDEFINED states to be acceptable is a workaround for this.
+  // The rationale is also that the robot controller should internally ignore EGM commands if it's in a bad state.
   return (current_.status().motor_state() == wrapper::Status_MotorState_MOTORS_ON &&
           current_.status().rapid_execution_state() != wrapper::Status_RAPIDExecutionState_RAPID_STOPPED &&
           current_.status().egm_state() == wrapper::Status_EGMState_EGM_RUNNING);


### PR DESCRIPTION
EGM knows about these RAPID execution states:
- `UNDEFINED`
- `STOPPED`
- `RUNNING`

There is a bug in EGM that after a restart of the robot controller, then RAPID is in the `UNDEFINED` state even if it has clearly been started. This PR makes both `RUNNING` and `UNDEFINED` states acceptable when sending commands. The rationale is that the robot controller should internally ignore EGM commands if it's in a bad state. 

It's been like this for some years now, and I have reported it a few times but it has not been fixed so far.

Also, I have used this workaround for years without problems.