### PR TITLE
Add CI job to test compilation on Windows with vcpkg

### DIFF
--- a/.github/workflows/windows-vcpkg.yml
+++ b/.github/workflows/windows-vcpkg.yml
@@ -1,0 +1,39 @@
+name: Windows vcpkg Workflow
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+  schedule:
+  # Execute a "nightly" build at 2 AM UTC 
+  - cron:  '0 2 * * *'
+
+jobs:
+  build:
+    name: 'Windows vcpkg job'
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    
+    # Restore from cache the previously built ports. If "cache miss"
+    # then provision vcpkg, install desired ports, finally cache everything for the next run.
+    - name: Restore from cache and run vcpkg
+      uses: lukka/run-vcpkg@v3
+      with:
+        vcpkgArguments: '--triplet x64-windows boost-asio boost-math boost-smart-ptr protobuf'
+        # commit from vcpkg's master branch on 2020/06/01
+        vcpkgGitCommitId: 6d36e2a86baf8d227fc6dce587bd69997d67fb5e
+        # Workaround for https://github.com/ros-industrial/abb_libegm/pull/101#discussion_r433370614
+        # This line can be removed once protobuf is  linked via its imported CMake targets
+        vcpkgDirectory: '${{ github.workspace }}/../vcpkg'  
+
+    - name: Configure the project 
+      shell: bash
+      run: | 
+        mkdir build
+        cd build
+        cmake -DCMAKE_TOOLCHAIN_FILE=${VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake ..
+        cmake --build . --config RelWithDebInfo
+        cmake --install . --config RelWithDebInfo


### PR DESCRIPTION
Fix https://github.com/ros-industrial/abb_libegm/issues/92 .

The problems discussed https://github.com/ros-industrial/abb_libegm/issues/92 were actually just due to a wrong order of arguments passed to CMake (`cmake --config Release  --build .` seems to ignore the `--build` flag). 

The correct compilation was tested in https://github.com/traversaro/abb_libegm/pull/2 .
The CI uses https://github.com/marketplace/actions/run-vcpkg to cache the installation of vcpkg dependencies, ensuring that the build on the master branch (after the first one, that is used to populate the cache) do not take ~20 minutes. 