### PR TITLE
Add definition for WRITE_TIMEOUT_MS and WAIT_TIME_MS static attributes

### DIFF
--- a/src/egm_base_interface.cpp
+++ b/src/egm_base_interface.cpp
@@ -761,6 +761,9 @@ bool EGMBaseInterface::OutputContainer::constructCartesianBody(const BaseConfigu
  * Class definitions: EGMBaseInterface
  */
 
+// See https://stackoverflow.com/questions/16957458/static-const-in-c-class-undefined-reference/16957554
+const unsigned int EGMBaseInterface::WAIT_TIME_MS;
+
 /************************************************************
  * Primary methods
  */

--- a/src/egm_controller_interface.cpp
+++ b/src/egm_controller_interface.cpp
@@ -47,6 +47,9 @@ namespace egm
  * Class definitions: EGMControllerInterface::ControllerMotion
  */
 
+// See https://stackoverflow.com/questions/16957458/static-const-in-c-class-undefined-reference/16957554
+const unsigned int EGMControllerInterface::ControllerMotion::WRITE_TIMEOUT_MS;
+
 /************************************************************
  * Primary methods
  */


### PR DESCRIPTION
See https://stackoverflow.com/questions/16957458/static-const-in-c-class-undefined-reference/16957554 for the extendend explanation.
Note that this constant may be accessed by reference, depending if standalone ASIO is used, or depending on the specific Boost::Asio version.

The problem appeared when compiling in Debug, and when using standalone Asio or Boost 1.69 or 1.71, while it was not happening when using Boost 1.65.

Fix https://github.com/ros-industrial/abb_libegm/issues/67 . 