### PR TITLE
Remove boost::math dependency

### DIFF
--- a/.github/workflows/windows-vcpkg.yml
+++ b/.github/workflows/windows-vcpkg.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Restore from cache and run vcpkg
       uses: lukka/run-vcpkg@v3
       with:
-        vcpkgArguments: '--triplet x64-windows boost-asio boost-math boost-smart-ptr protobuf'
+        vcpkgArguments: '--triplet x64-windows boost-asio boost-smart-ptr protobuf'
         # commit from vcpkg's master branch on 2020/06/01
         vcpkgGitCommitId: 6d36e2a86baf8d227fc6dce587bd69997d67fb5e
         # Workaround for https://github.com/ros-industrial/abb_libegm/pull/101#discussion_r433370614

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,6 +66,10 @@ if(NOT DEFINED BUILD_SHARED_LIBS)
   option(BUILD_SHARED_LIBS "Build dynamically-linked binaries" ON)
 endif()
 
+if(NOT DEFINED BUILD_TESTING)
+  option(BUILD_TESTING "Build tests" OFF)
+endif()
+
 set(
   SRC_FILES
     src/egm_base_interface.cpp
@@ -163,3 +167,10 @@ install(
   FILE ${PROJECT_NAME}Targets.cmake
   NAMESPACE ${PROJECT_NAME}::
 )
+
+if(BUILD_TESTING)
+  enable_testing()
+  add_executable(egm_common_auxiliary_TEST tests/egm_common_auxiliary_test.cpp)
+  target_link_libraries(egm_common_auxiliary_TEST PRIVATE ${PROJECT_NAME}::${PROJECT_NAME})
+  add_test(NAME egm_common_auxiliary_TEST COMMAND egm_common_auxiliary_TEST)
+endif()

--- a/tests/egm_common_auxiliary_test.cpp
+++ b/tests/egm_common_auxiliary_test.cpp
@@ -1,0 +1,86 @@
+/***********************************************************************************************************************
+ *
+ * Copyright (c) 2020, ABB Schweiz AG
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with
+ * or without modification, are permitted provided that
+ * the following conditions are met:
+ *
+ *    * Redistributions of source code must retain the
+ *      above copyright notice, this list of conditions
+ *      and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the
+ *      above copyright notice, this list of conditions
+ *      and the following disclaimer in the documentation
+ *      and/or other materials provided with the
+ *      distribution.
+ *    * Neither the name of ABB nor the names of its
+ *      contributors may be used to endorse or promote
+ *      products derived from this software without
+ *      specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ***********************************************************************************************************************
+ */
+
+#include <cstdlib>
+#include <iostream>
+
+#include "abb_libegm/egm_common_auxiliary.h"
+
+#include <google/protobuf/text_format.h>
+
+bool estimateVelocitiesTest()
+{
+  abb::egm::wrapper::Euler estimate;
+  double sample_time = 0.001;
+  abb::egm::wrapper::Euler previousEuler = abb::egm::wrapper::Euler::default_instance();
+  previousEuler.set_x(0.0);
+  previousEuler.set_y(0.0);
+  previousEuler.set_z(0.0);
+  abb::egm::wrapper::Quaternion previous;
+  abb::egm::convert(&previous, previousEuler);
+  abb::egm::wrapper::Euler currentEuler = abb::egm::wrapper::Euler::default_instance();
+  currentEuler.set_x(0.01);
+  currentEuler.set_y(0.01);
+  currentEuler.set_z(0.01);
+  abb::egm::wrapper::Quaternion current;
+  abb::egm::convert(&current, currentEuler);
+  abb::egm::estimateVelocities(&estimate, current, previous, sample_time);
+  double eps = 1e-8;
+  if (std::abs(9.9991272465327938 - estimate.x()) > eps)
+  {
+    return false;
+  }
+  if (std::abs(10.000872575773712 - estimate.y()) > eps)
+  {
+      return false;
+  }
+  if (std::abs(9.9991272465327938 - estimate.z()) > eps)
+  {
+      return false;
+  }
+  return true;
+}
+
+int main()
+{
+  if (!estimateVelocitiesTest())
+  {
+    std::cerr << "estimateVelocitiesTest FAILED" << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  return EXIT_SUCCESS;
+}


### PR DESCRIPTION
As discussed in https://github.com/ros-industrial/abb_libegm/issues/70#issuecomment-584000173 : 
> Remove the boost::math dependency by implementing the quaternion conjugate operation, which should be straight-forward. 

It turns out that it was necessary also to implement a couple more operators, so the PR is ready but it is mostly open just to receive feedback, in particular: 
* I added  a test to ensure that the `estimateVelocity` continued to work exactly as it did with boost::math . For the time being I did not use any test library, if you have any preference I can migrate the test to your favored framework. 
* To ensure that the code remained real-time safe with no allocation as it was before, I could not define functions that operated on the `abb::egm::wrapper::Quaternion` structure, but I had to introduce a small private class to contain internal quaternion operations. I intentionally hided this object from the public headers to avoid to maintain them in the future, let me know if this is ok.  