### PR TITLE
Added export macro to generated protobuf C++ files, and force include generated export header

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,12 @@ set(EgmProtoFiles proto/egm.proto proto/egm_wrapper.proto proto/egm_wrapper_traj
 if(NOT QUIET)
   message(STATUS "Generating protobuf C++ for: ${EgmProtoFiles}")
 endif()
-protobuf_generate_cpp(EgmProtoSources EgmProtoHeaders ${EgmProtoFiles})
+if(MSVC)
+  # Add export macro when using Microsoft Visual C++ compiler.
+  protobuf_generate_cpp(EgmProtoSources EgmProtoHeaders EXPORT_MACRO ABB_LIBEGM_EXPORT ${EgmProtoFiles})
+else()
+  protobuf_generate_cpp(EgmProtoSources EgmProtoHeaders ${EgmProtoFiles})
+endif()
 
 #############
 ## Threads ##
@@ -101,6 +106,11 @@ target_link_libraries(${PROJECT_NAME} PUBLIC
 
 if(NOT BUILD_SHARED_LIBS)
   target_compile_definitions(${PROJECT_NAME} PUBLIC "ABB_LIBEGM_STATIC_DEFINE")
+endif()
+
+if(MSVC)
+  # Force include the export header when using Microsoft Visual C++ compiler.
+  target_compile_options(${PROJECT_NAME} PUBLIC "/FI${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_export.h")
 endif()
 
 #############


### PR DESCRIPTION
As per title.

This is based on https://github.com/ros-industrial/abb_libegm/pull/63#issuecomment-557553377, for a solution to linking issues for shared libraries when using `MSVC`.