### PR TITLE
Use latest vcpkg

### DIFF
--- a/.github/workflows/windows-vcpkg.yml
+++ b/.github/workflows/windows-vcpkg.yml
@@ -6,7 +6,7 @@ on:
       - master
   pull_request:
   schedule:
-  # Execute a "nightly" build at 2 AM UTC
+  # Execute a "nightly" build at 2 AM UTC.
   - cron:  '0 2 * * *'
 
 jobs:
@@ -17,16 +17,16 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    # Restore from cache the previously built ports. If "cache miss"
-    # then provision vcpkg, install desired ports, finally cache everything for the next run.
+    # Restore from cache the previously built ports. If "cache miss" then provision vcpkg,
+    # install desired ports, finally cache everything for the next run.
     - name: Restore from cache and run vcpkg
       uses: lukka/run-vcpkg@v5
       with:
         vcpkgArguments: '--triplet x64-windows boost-asio boost-math boost-smart-ptr protobuf'
-        # commit corresponding to vcpkg's release v2020.11
+        # Commit corresponding to vcpkg's release v2020.11.
         vcpkgGitCommitId: 0bf3923f9fab4001c00f0f429682a0853b5749e0
-        # Workaround for https://github.com/ros-industrial/abb_libegm/pull/101#discussion_r433370614
-        # This line can be removed once protobuf is linked via its imported CMake targets
+        # Workaround for https://github.com/ros-industrial/abb_libegm/pull/101#discussion_r433370614.
+        # This line can be removed once protobuf is linked via its imported CMake targets.
         vcpkgDirectory: '${{ github.workspace }}/../vcpkg'
 
     - name: Configure the project

--- a/.github/workflows/windows-vcpkg.yml
+++ b/.github/workflows/windows-vcpkg.yml
@@ -6,7 +6,7 @@ on:
       - master
   pull_request:
   schedule:
-  # Execute a "nightly" build at 2 AM UTC 
+  # Execute a "nightly" build at 2 AM UTC
   - cron:  '0 2 * * *'
 
 jobs:
@@ -16,7 +16,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    
+
     # Restore from cache the previously built ports. If "cache miss"
     # then provision vcpkg, install desired ports, finally cache everything for the next run.
     - name: Restore from cache and run vcpkg
@@ -26,12 +26,12 @@ jobs:
         # commit corresponding to vcpkg's release v2020.11
         vcpkgGitCommitId: 0bf3923f9fab4001c00f0f429682a0853b5749e0
         # Workaround for https://github.com/ros-industrial/abb_libegm/pull/101#discussion_r433370614
-        # This line can be removed once protobuf is  linked via its imported CMake targets
-        vcpkgDirectory: '${{ github.workspace }}/../vcpkg'  
+        # This line can be removed once protobuf is linked via its imported CMake targets
+        vcpkgDirectory: '${{ github.workspace }}/../vcpkg'
 
-    - name: Configure the project 
+    - name: Configure the project
       shell: bash
-      run: | 
+      run: |
         mkdir build
         cd build
         cmake -DCMAKE_TOOLCHAIN_FILE=${VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake ..

--- a/.github/workflows/windows-vcpkg.yml
+++ b/.github/workflows/windows-vcpkg.yml
@@ -23,8 +23,8 @@ jobs:
       uses: lukka/run-vcpkg@v5
       with:
         vcpkgArguments: '--triplet x64-windows boost-asio boost-math boost-smart-ptr protobuf'
-        # Commit corresponding to vcpkg's release v2020.11.
-        vcpkgGitCommitId: 0bf3923f9fab4001c00f0f429682a0853b5749e0
+        # Commit corresponding to vcpkg's master branch on 2020-11-20.
+        vcpkgGitCommitId: e803bf11296d8e7900dafb41e7b1224778d33dc6
         # Workaround for https://github.com/ros-industrial/abb_libegm/pull/101#discussion_r433370614.
         # This line can be removed once protobuf is linked via its imported CMake targets.
         vcpkgDirectory: '${{ github.workspace }}/../vcpkg'


### PR DESCRIPTION
As per title.

Reason is to be conistance with the [abb_librws](https://github.com/ros-industrial/abb_librws) companion library, see https://github.com/ros-industrial/abb_librws/pull/125#issuecomment-731275373.

I also updated comments and removed extra whitespaces.