### PR TITLE
Added an optional condition variable for notifying external control loops

### DIFF
--- a/include/abb_libegm/egm_common.h
+++ b/include/abb_libegm/egm_common.h
@@ -37,6 +37,9 @@
 #ifndef EGM_COMMON_H
 #define EGM_COMMON_H
 
+#include <boost/shared_ptr.hpp>
+#include <boost/thread/condition_variable.hpp>
+
 #include "abb_libegm_export.h"
 
 namespace abb
@@ -178,6 +181,13 @@ struct BaseConfiguration
    * \brief Maximum duration [s] to log data.
    */
   double max_logging_duration;
+
+  /**
+   * \brief Optional condition variable intended for notifying an external control loop that a new message is available.
+   *
+   * Note: This is only intended to be used in the EGMControllerInterface class.
+   */
+  boost::shared_ptr<boost::condition_variable> p_new_message_cv;
 };
 
 /**

--- a/src/egm_controller_interface.cpp
+++ b/src/egm_controller_interface.cpp
@@ -179,6 +179,12 @@ const std::string& EGMControllerInterface::callback(const UDPServerData& server_
       // Make the current inputs available (to the external control loop), and notify that it is available.
       controller_motion_.writeInputs(inputs_.current());
 
+      // Send a notification via the (optional) external condition variable.
+      if(configuration_.active.p_new_message_cv)
+      {
+        configuration_.active.p_new_message_cv->notify_all();
+      }
+
       if (inputs_.isFirstMessage() || inputs_.statesOk())
       {
         // Wait for new outputs (from the external control loop), or until a timeout occurs.


### PR DESCRIPTION
As per title.

This can for example be useful when having multiple communication channels. I.e. for getting a notification that any of the channels have received an EGM message.