### PR TITLE
Expose measured force torque data

### DIFF
--- a/include/abb_libegm/egm_common_auxiliary.h
+++ b/include/abb_libegm/egm_common_auxiliary.h
@@ -389,6 +389,16 @@ bool parse(wrapper::Joints* p_target_robot,
 bool parse(wrapper::CartesianPose* p_target, const EgmPose& source);
 
 /**
+ * \brief Parse an abb::egm::EgmMeasuredForce object.
+ *
+ * \param p_target for containing the parsed data.
+ * \param source containing data to parse.
+ *
+ * \return bool indicating if the parsing was successful or not.
+ */
+bool parse(wrapper::ForceTorque* p_target, const EgmMeasuredForce& source);
+
+/**
  * \brief Parse an abb::egm::EgmFeedBack object.
  *
  * \param p_target for containing the parsed data.

--- a/proto/egm_wrapper.proto
+++ b/proto/egm_wrapper.proto
@@ -207,6 +207,32 @@ message Planned
 
 //======================================================================================================================
 //
+// Force torque sensor measurments.
+//
+//======================================================================================================================
+
+message Force
+{
+  optional double x = 1;
+  optional double y = 2;
+  optional double z = 3;
+}
+
+message Torque
+{
+  optional double x = 1;
+  optional double y = 2;
+  optional double z = 3;
+}
+
+message ForceTorque
+{
+  optional Force force = 1;
+  optional Torque torque = 2;
+}
+
+//======================================================================================================================
+//
 // Primary messages.
 //
 //======================================================================================================================
@@ -218,6 +244,7 @@ message Input
   optional Feedback feedback = 2;
   optional Planned  planned  = 3;
   optional Status   status   = 4;
+  optional ForceTorque forcetorque = 5;
 }
 
 // Outputs to send to the robot controller.

--- a/src/egm_base_interface.cpp
+++ b/src/egm_base_interface.cpp
@@ -90,7 +90,8 @@ bool EGMBaseInterface::InputContainer::extractParsedInformation(const RobotAxes&
       parse(current_.mutable_header(), egm_robot_.header()) &&
       parse(current_.mutable_feedback(), egm_robot_.feedback(), axes) &&
       parse(current_.mutable_planned(), egm_robot_.planned(), axes) &&
-      parse(current_.mutable_status(), egm_robot_))
+      parse(current_.mutable_status(), egm_robot_) &&
+      parse(current_.mutable_forcetorque(), egm_robot_.measuredforce()))
   {
     if (first_message_)
     {

--- a/src/egm_common_auxiliary.cpp
+++ b/src/egm_common_auxiliary.cpp
@@ -851,21 +851,26 @@ bool parse(wrapper::ForceTorque* p_target, const EgmMeasuredForce& source)
     return false;
   }
 
-  if (source.force_size() != 6)
+  if (source.force_size() == 6)
   {
-    p_target->Clear();  // No FT data
-    return true;  // No FT sensor is not an error
+    // Read out force torque data (6 DOF)
+    p_target->mutable_force()->set_x(source.force().at(0));
+    p_target->mutable_force()->set_y(source.force().at(1));
+    p_target->mutable_force()->set_z(source.force().at(2));
+    p_target->mutable_torque()->set_x(source.force().at(3));
+    p_target->mutable_torque()->set_y(source.force().at(4));
+    p_target->mutable_torque()->set_z(source.force().at(5));
+    return true;
+  }
+  else if (source.force_size() == 1)
+  {
+    // Read out force torque data (1 DOF)
+    p_target->mutable_force()->set_x(source.force().at(0));
+    return true;
   }
 
-  // Read out force torque data
-  p_target->mutable_force()->set_x(source.force().at(0));
-  p_target->mutable_force()->set_y(source.force().at(1));
-  p_target->mutable_force()->set_z(source.force().at(2));
-  p_target->mutable_torque()->set_x(source.force().at(3));
-  p_target->mutable_torque()->set_y(source.force().at(4));
-  p_target->mutable_torque()->set_z(source.force().at(5));
-
-  return true;
+  p_target->Clear();  // No FT data
+  return true;  // No FT sensor is not an error
 }
 
 

--- a/src/egm_common_auxiliary.cpp
+++ b/src/egm_common_auxiliary.cpp
@@ -844,6 +844,31 @@ bool parse(wrapper::CartesianPose* p_target, const EgmPose& source)
   return success;
 }
 
+bool parse(wrapper::ForceTorque* p_target, const EgmMeasuredForce& source)
+{
+  if (!p_target)
+  {
+    return false;
+  }
+
+  if (source.force_size() != 6)
+  {
+    p_target->Clear();  // No FT data
+    return true;  // No FT sensor is not an error
+  }
+
+  // Read out force torque data
+  p_target->mutable_force()->set_x(source.force().at(0));
+  p_target->mutable_force()->set_y(source.force().at(1));
+  p_target->mutable_force()->set_z(source.force().at(2));
+  p_target->mutable_torque()->set_x(source.force().at(3));
+  p_target->mutable_torque()->set_y(source.force().at(4));
+  p_target->mutable_torque()->set_z(source.force().at(5));
+
+  return true;
+}
+
+
 bool parse(wrapper::Feedback* p_target, const EgmFeedBack& source, const RobotAxes axes)
 {
   bool success = false;


### PR DESCRIPTION
An addition to expose the `measuredForce` field from the `abb.egm.EgmRobot` protobuf message, to allow downstream code to read out the force-torque sensor data.

The code should be compatible with both 6DOF and 1DOF sensors, although I have only been able to test it with a 6DOF sensor. Behaviour should remain unchanged if the `measuredForce` field is empty.

I have already made the extra additions to [abb_egm_rws_managers](https://github.com/ros-industrial/abb_egm_rws_managers) and [abb_ros2](https://github.com/PickNikRobotics/abb_ros2) to allow the force torque data from a real robot with 6DOF FT sensor to be published by a standard [ForceTorqueSensorBroadcaster](https://control.ros.org/master/doc/ros2_controllers/force_torque_sensor_broadcaster/doc/userdoc.html). I will open PR's on those repositories once/if this change is accepted here.

Note: this is for external FT sensors, not for internal joint-torque measurements as discussed in #86.